### PR TITLE
Print atomic dispersion energies

### DIFF
--- a/app/driver.f90
+++ b/app/driver.f90
@@ -177,7 +177,7 @@ subroutine run_driver(config, error)
    end if
 
    if (allocated(param)) then
-      call get_dispersion_atomic(mol, d3, param, realspace_cutoff(), energies,&
+      call get_dispersion(mol, d3, param, realspace_cutoff(), energies, &
          & gradient, sigma)
       energy = sum(energies)
 

--- a/app/driver.f90
+++ b/app/driver.f90
@@ -51,9 +51,10 @@ subroutine run_driver(config, error)
    class(damping_param), allocatable :: param
    type(d3_param) :: inp
    type(d3_model) :: d3
-   real(wp), allocatable :: energy, gradient(:, :), sigma(:, :)
+   real(wp), allocatable :: energies(:), gradient(:, :), sigma(:, :)
    real(wp), allocatable :: pair_disp2(:, :), pair_disp3(:, :)
    real(wp), allocatable :: s9
+   real(wp) :: energy
    integer :: stat, unit
    logical :: exist
 
@@ -163,7 +164,7 @@ subroutine run_driver(config, error)
    end if
 
    if (allocated(param)) then
-      energy = 0.0_wp
+      allocate(energies(mol%nat))
       if (config%grad) then
          allocate(gradient(3, mol%nat), sigma(3, 3))
       end if
@@ -176,14 +177,19 @@ subroutine run_driver(config, error)
    end if
 
    if (allocated(param)) then
-      call get_dispersion(mol, d3, param, realspace_cutoff(), energy, gradient, &
-         & sigma)
+      call get_dispersion_atomic(mol, d3, param, realspace_cutoff(), energies,&
+         & gradient, sigma)
+      energy = sum(energies)
+
       if (config%pair_resolved) then
          allocate(pair_disp2(mol%nat, mol%nat), pair_disp3(mol%nat, mol%nat))
          call get_pairwise_dispersion(mol, d3, param, realspace_cutoff(), pair_disp2, &
             & pair_disp3)
       end if
       if (config%verbosity > 0) then
+         if (config%verbosity > 2) then
+            call ascii_energy_atom(output_unit, mol, energies)
+         end if
          call ascii_results(output_unit, mol, energy, gradient, sigma)
          if (config%pair_resolved) then
             call ascii_pairwise(output_unit, mol, pair_disp2, pair_disp3)

--- a/src/dftd3.f90
+++ b/src/dftd3.f90
@@ -16,7 +16,8 @@
 
 module dftd3
    use dftd3_cutoff, only : realspace_cutoff, get_lattice_points
-   use dftd3_disp, only : get_dispersion, get_pairwise_dispersion
+   use dftd3_disp, only : get_dispersion_atomic, get_dispersion, &
+      & get_pairwise_dispersion
    use dftd3_ncoord, only : get_coordination_number
    use dftd3_damping, only : damping_param
    use dftd3_damping_mzero, only : mzero_damping_param, new_mzero_damping
@@ -31,7 +32,8 @@ module dftd3
    implicit none
    private
 
-   public :: get_dispersion, get_pairwise_dispersion, get_coordination_number
+   public :: get_dispersion_atomic, get_dispersion, get_pairwise_dispersion
+   public :: get_coordination_number
    public :: realspace_cutoff, get_lattice_points
    public :: damping_param, d3_param
    public :: get_rational_damping, get_zero_damping

--- a/src/dftd3.f90
+++ b/src/dftd3.f90
@@ -16,8 +16,7 @@
 
 module dftd3
    use dftd3_cutoff, only : realspace_cutoff, get_lattice_points
-   use dftd3_disp, only : get_dispersion_atomic, get_dispersion, &
-      & get_pairwise_dispersion
+   use dftd3_disp, only : get_dispersion, get_pairwise_dispersion
    use dftd3_ncoord, only : get_coordination_number
    use dftd3_damping, only : damping_param
    use dftd3_damping_mzero, only : mzero_damping_param, new_mzero_damping
@@ -32,7 +31,7 @@ module dftd3
    implicit none
    private
 
-   public :: get_dispersion_atomic, get_dispersion, get_pairwise_dispersion
+   public :: get_dispersion, get_pairwise_dispersion
    public :: get_coordination_number
    public :: realspace_cutoff, get_lattice_points
    public :: damping_param, d3_param

--- a/src/dftd3/disp.f90
+++ b/src/dftd3/disp.f90
@@ -27,12 +27,19 @@ module dftd3_disp
    implicit none
    private
 
-   public :: get_dispersion_atomic, get_dispersion, get_pairwise_dispersion
+   public :: get_dispersion, get_pairwise_dispersion
 
+
+   !> Calculate dispersion energy
+   interface get_dispersion
+      module procedure :: get_dispersion_atomic
+      module procedure :: get_dispersion_scalar
+   end interface get_dispersion
 
 contains
 
 
+!> Calculate atom-resolved dispersion energies.
 subroutine get_dispersion_atomic(mol, disp, param, cutoff, energies, gradient, sigma)
 
    !> Molecular structure data
@@ -100,7 +107,8 @@ subroutine get_dispersion_atomic(mol, disp, param, cutoff, energies, gradient, s
 end subroutine get_dispersion_atomic
 
 
-subroutine get_dispersion(mol, disp, param, cutoff, energy, gradient, sigma)
+!> Calculate scalar dispersion energy.
+subroutine get_dispersion_scalar(mol, disp, param, cutoff, energy, gradient, sigma)
 
    !> Molecular structure data
    class(structure_type), intent(in) :: mol
@@ -131,7 +139,7 @@ subroutine get_dispersion(mol, disp, param, cutoff, energy, gradient, sigma)
 
    energy = sum(energies)
 
-end subroutine get_dispersion
+end subroutine get_dispersion_scalar
 
 
 !> Wrapper to handle the evaluation of pairwise representation of the dispersion energy

--- a/src/dftd3/output.f90
+++ b/src/dftd3/output.f90
@@ -30,6 +30,7 @@ module dftd3_output
    private
 
    public :: ascii_atomic_radii, ascii_atomic_references, ascii_system_properties
+   public :: ascii_energy_atom
    public :: ascii_results, ascii_damping_param, ascii_pairwise
    public :: turbomole_gradient, turbomole_gradlatt
    public :: json_results, tagged_result
@@ -139,6 +140,34 @@ subroutine ascii_system_properties(unit, mol, disp, cn, c6)
 end subroutine ascii_system_properties
 
 
+subroutine ascii_energy_atom(unit, mol, energies)
+
+   !> Unit for output
+   integer, intent(in) :: unit
+
+   !> Molecular structure data
+   class(structure_type), intent(in) :: mol
+
+   !> Atom-resolved dispersion energies
+   real(wp), allocatable, intent(in) :: energies(:)
+
+   integer :: iat, isp
+
+   write(unit, '(a,":")') "Atom-resolved dispersion energies"
+   write(unit, '(50("-"))')
+   write(unit, '(a6,1x,a4,1x,4x,a15,1x,a15)') "#", "Z", "[Hartree]", "[kcal/mol]"
+   write(unit, '(50("-"))')
+   do iat = 1, mol%nat
+      isp = mol%id(iat)
+      write(unit, '(i6,1x,i4,1x,a4,e15.8,1x,f15.8)') &
+         & iat, mol%num(isp), mol%sym(isp), energies(iat), energies(iat)*autokcal
+   end do
+   write(unit, '(50("-"))')
+   write(unit, '(a)')
+
+end subroutine ascii_energy_atom
+
+   
 subroutine ascii_results(unit, mol, energy, gradient, sigma)
 
    !> Unit for output

--- a/src/dftd3/output.f90
+++ b/src/dftd3/output.f90
@@ -140,6 +140,7 @@ subroutine ascii_system_properties(unit, mol, disp, cn, c6)
 end subroutine ascii_system_properties
 
 
+!> Print atom-resolved dispersion energies
 subroutine ascii_energy_atom(unit, mol, energies)
 
    !> Unit for output


### PR DESCRIPTION
- print atomic dispersion energies in Hartree and kcal/mol
- requires additional verbosity level (i.e., >2)

<details>
<summary>Example Output</summary>

```
-----------------------------------
 s i m p l e   D F T - D 3  v1.0.0
-----------------------------------

Rational (Becke-Johnson) damping: D3(BJ)
---------------------
  s6         1.0000
  s8         2.4000
  s9         0.0000
  a1         0.6300
  a2         5.0000
 alp        14.0000
--------------------

Atom-resolved dispersion energies:
--------------------------------------------------
     #    Z           [Hartree]      [kcal/mol]
--------------------------------------------------
     1   11 Na  -0.76748306E-03     -0.48160289
     2    1 H   -0.24893380E-03     -0.15620832
     3    8 O   -0.36382575E-03     -0.22830411
     4    1 H   -0.28480067E-03     -0.17871512
     5    9 F   -0.30407223E-03     -0.19080820
     6    1 H   -0.30221975E-03     -0.18964576
     7    1 H   -0.35383148E-03     -0.22203261
     8    8 O   -0.43647474E-03     -0.27389203
     9    7 N   -0.66531601E-03     -0.41749210
    10    1 H   -0.24273005E-03     -0.15231541
    11    1 H   -0.28733317E-03     -0.18030428
    12   17 Cl  -0.97017183E-03     -0.60879201
    13    5 B   -0.57848073E-03     -0.36300214
    14    5 B   -0.57521461E-03     -0.36095262
    15    7 N   -0.59906392E-03     -0.37591828
    16   13 Al  -0.10276807E-02     -0.64487938
--------------------------------------------------

Dispersion energy:      -8.0076324944923E-03 Eh

[Info] Dispersion energy written to .EDISP

```
</details>