### PR TITLE
Binary distribution for Python 3.12

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     defaults:
       run:


### PR DESCRIPTION
Python 3.12 is now the default on Ubuntu 24.04, so this adds a binary distribution for python 3.12 to the CI.