### PR TITLE
Fix periodic PySCF calculations

### DIFF
--- a/python/dftd3/pyscf.py
+++ b/python/dftd3/pyscf.py
@@ -220,9 +220,17 @@ class DFTD3Dispersion(lib.StreamObject):
         """
         mol = self.mol
 
+        lattice = None
+        periodic = None
+        if callable(getattr(mol, 'lattice_vectors')):
+            lattice = mol.lattice_vectors()
+            periodic = np.array([True,True,True], dtype=bool)
+
         disp = DispersionModel(
             np.array([gto.charge(mol.atom_symbol(ia)) for ia in range(mol.natm)]),
             mol.atom_coords(),
+            lattice=lattice,
+            periodic=periodic,
         )
 
         if self.param is not None:

--- a/python/dftd3/pyscf.py
+++ b/python/dftd3/pyscf.py
@@ -222,9 +222,9 @@ class DFTD3Dispersion(lib.StreamObject):
 
         lattice = None
         periodic = None
-        if callable(getattr(mol, 'lattice_vectors')):
+        if hasattr(mol, 'lattice_vectors'):
             lattice = mol.lattice_vectors()
-            periodic = np.array([True,True,True], dtype=bool)
+            periodic = np.array([True, True, True], dtype=bool)
 
         disp = DispersionModel(
             np.array([gto.charge(mol.atom_symbol(ia)) for ia in range(mol.natm)]),

--- a/python/dftd3/test_pyscf.py
+++ b/python/dftd3/test_pyscf.py
@@ -20,7 +20,7 @@ from pytest import approx, raises
 
 try:
     import pyscf
-    from pyscf import lib, gto, scf, pbc
+    from pyscf import gto, scf, pbc
     import dftd3.pyscf as disp
 except ModuleNotFoundError:
     pyscf = None


### PR DESCRIPTION
Fix for https://github.com/dftd3/simple-dftd3/issues/73

Checks if the `mol.lattice_vectors()` method exists, rather than checking if the mol is an instance of `pyscf.pbc.gto.Cell` specifically