### PR TITLE
Workarounds for Cray compilers

### DIFF
--- a/src/dftd3/output.f90
+++ b/src/dftd3/output.f90
@@ -289,8 +289,11 @@ subroutine ascii_damping_param(unit, param, method)
       if (present(method)) then
          write(unit, '(a, "-")', advance="no") method
       end if
-      write(unit, '(a)') &
-         & trim(merge("D3(0)-ATM", "D3(0)    ", abs(param%s9) > 0))
+      if ( abs(param%s9) > 0 ) then
+         write(unit, '(a)') "D3(0)-ATM"
+      else
+         write(unit, '(a)') "D3(0)"
+      endif
       write(unit, '(20("-"))')
       write(unit, '(a4, t10, f10.4)') &
          & "s6", param%s6, &
@@ -306,8 +309,11 @@ subroutine ascii_damping_param(unit, param, method)
       if (present(method)) then
          write(unit, '(a, "-")', advance="no") method
       end if
-      write(unit, '(a)') &
-         & trim(merge("D3(0M)-ATM", "D3(0M)    ", abs(param%s9) > 0))
+      if ( abs(param%s9) > 0 ) then
+         write(unit, '(a)') "D3(0M)-ATM"
+      else
+         write(unit, '(a)') "D3(0M)"
+      endif
       write(unit, '(20("-"))')
       write(unit, '(a5, t10, f10.4)') &
          & "s6", param%s6, &
@@ -324,8 +330,11 @@ subroutine ascii_damping_param(unit, param, method)
       if (present(method)) then
          write(unit, '(a, "-")', advance="no") method
       end if
-      write(unit, '(a)') &
-         & trim(merge("D3(op)-ATM", "D3(op)    ", abs(param%s9) > 0))
+      if ( abs(param%s9) > 0 ) then
+         write(unit, '(a)') "D3(op)-ATM"
+      else
+         write(unit, '(a)') "D3(op)"
+      endif
       write(unit, '(20("-"))')
       write(unit, '(a5, t10, f10.4)') &
          & "s6", param%s6, &
@@ -342,8 +351,11 @@ subroutine ascii_damping_param(unit, param, method)
       if (present(method)) then
          write(unit, '(a, "-")', advance="no") method
       end if
-      write(unit, '(a)') &
-         & trim(merge("D3(BJ)-ATM", "D3(BJ)    ", abs(param%s9) > 0))
+      if ( abs(param%s9) > 0 ) then
+         write(unit, '(a)') "D3(BJ)-ATM"
+      else
+         write(unit, '(a)') "D3(BJ)"
+      endif
       write(unit, '(21("-"))')
       write(unit, '(a4, t10, f10.4)') &
          & "s6", param%s6, &

--- a/src/dftd3/output.f90
+++ b/src/dftd3/output.f90
@@ -289,11 +289,11 @@ subroutine ascii_damping_param(unit, param, method)
       if (present(method)) then
          write(unit, '(a, "-")', advance="no") method
       end if
-      if ( abs(param%s9) > 0 ) then
+      if (abs(param%s9) > 0) then
          write(unit, '(a)') "D3(0)-ATM"
       else
          write(unit, '(a)') "D3(0)"
-      endif
+      end if
       write(unit, '(20("-"))')
       write(unit, '(a4, t10, f10.4)') &
          & "s6", param%s6, &

--- a/src/dftd3/output.f90
+++ b/src/dftd3/output.f90
@@ -309,11 +309,11 @@ subroutine ascii_damping_param(unit, param, method)
       if (present(method)) then
          write(unit, '(a, "-")', advance="no") method
       end if
-      if ( abs(param%s9) > 0 ) then
+      if (abs(param%s9) > 0) then
          write(unit, '(a)') "D3(0M)-ATM"
       else
          write(unit, '(a)') "D3(0M)"
-      endif
+      end if
       write(unit, '(20("-"))')
       write(unit, '(a5, t10, f10.4)') &
          & "s6", param%s6, &
@@ -330,11 +330,11 @@ subroutine ascii_damping_param(unit, param, method)
       if (present(method)) then
          write(unit, '(a, "-")', advance="no") method
       end if
-      if ( abs(param%s9) > 0 ) then
+      if (abs(param%s9) > 0) then
          write(unit, '(a)') "D3(op)-ATM"
       else
          write(unit, '(a)') "D3(op)"
-      endif
+      end if
       write(unit, '(20("-"))')
       write(unit, '(a5, t10, f10.4)') &
          & "s6", param%s6, &
@@ -351,11 +351,11 @@ subroutine ascii_damping_param(unit, param, method)
       if (present(method)) then
          write(unit, '(a, "-")', advance="no") method
       end if
-      if ( abs(param%s9) > 0 ) then
+      if (abs(param%s9) > 0) then
          write(unit, '(a)') "D3(BJ)-ATM"
       else
          write(unit, '(a)') "D3(BJ)"
-      endif
+      end if
       write(unit, '(21("-"))')
       write(unit, '(a4, t10, f10.4)') &
          & "s6", param%s6, &

--- a/src/dftd3/reference.f90
+++ b/src/dftd3/reference.f90
@@ -148,7 +148,7 @@ module dftd3_reference
          & +0.0000_wp, +0.9710_wp, +1.9564_wp, +2.9515_wp, +3.9353_wp, -1.0000_wp, -1.0000_wp, &   ! Md
          & +0.0000_wp, +0.9722_wp, +1.9605_wp, +2.9452_wp, +3.9296_wp, +4.2582_wp, +4.5511_wp, &   ! No
          & +0.0000_wp, +0.9569_wp, +1.9215_wp, +2.8958_wp, +3.7644_wp, +4.6808_wp, +5.5939_wp],&   ! Lr
-      & (/max_ref,max_elem/))
+         & [max_ref, max_elem])
 
 
    real(wp), allocatable :: reference_c6(:, :, :)

--- a/src/dftd3/reference.f90
+++ b/src/dftd3/reference.f90
@@ -148,7 +148,7 @@ module dftd3_reference
          & +0.0000_wp, +0.9710_wp, +1.9564_wp, +2.9515_wp, +3.9353_wp, -1.0000_wp, -1.0000_wp, &   ! Md
          & +0.0000_wp, +0.9722_wp, +1.9605_wp, +2.9452_wp, +3.9296_wp, +4.2582_wp, +4.5511_wp, &   ! No
          & +0.0000_wp, +0.9569_wp, +1.9215_wp, +2.8958_wp, +3.7644_wp, +4.6808_wp, +5.5939_wp],&   ! Lr
-      & shape(reference_cn))
+      & (/max_ref,max_elem/))
 
 
    real(wp), allocatable :: reference_c6(:, :, :)


### PR DESCRIPTION
Implements the workarounds for Cray compilers mentioned in #76.

Closes #76.