### PR TITLE
Fix python3.12 build failure

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -68,7 +68,7 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        - windows-latest
+        # windows-latest
         - macos-12
         python: ['38', '39', '310', '311', '312']
 

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -70,7 +70,7 @@ jobs:
         - ubuntu-latest
         - windows-latest
         - macos-12
-        python: ['38', '39', '310', '311']
+        python: ['38', '39', '310', '311', '312']
 
     defaults:
       run:
@@ -97,7 +97,7 @@ jobs:
           CIBW_BUILD: "*${{ matrix.python }}-*"
           CIBW_BUILD_VERBOSITY: 1
           CIBW_ARCHS_MACOS: x86_64
-          CIBW_ENVIRONMENT_MACOS: CC=gcc-11 CXX=g++-11 FC=gfortran-11 MACOSX_DEPLOYMENT_TARGET=12.0
+          CIBW_ENVIRONMENT_MACOS: CC=gcc-12 CXX=g++-12 FC=gfortran-12 MACOSX_DEPLOYMENT_TARGET=12.0
           CIBW_BEFORE_BUILD_WINDOWS: choco upgrade mingw && pip install delvewheel
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel show {wheel} && delvewheel repair -w {dest_dir} {wheel} --no-mangle-all"
 

--- a/python/dftd3/meson.build
+++ b/python/dftd3/meson.build
@@ -20,7 +20,8 @@ pymod = import('python')
 python = pymod.find_installation(
   get_option('python_version'),
   modules: [
-    'cffi',
+    'cffi',  # Needed for generating the FFI interface
+    'setuptools',  # Needed for running ffi-builder.py
   ],
 )
 python_dep = python.dependency(required: true)

--- a/python/dftd3/test_interface.py
+++ b/python/dftd3/test_interface.py
@@ -116,6 +116,7 @@ def test_optimized_power_damping_noargs():
 def test_structure():
     """check if the molecular structure data is working as expected."""
 
+    rng = np.random.default_rng()
     numbers = np.array(
         [6, 7, 6, 7, 6, 6, 6, 8, 7, 6, 8, 7, 6, 6, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
     )
@@ -158,18 +159,18 @@ def test_structure():
 
     # Also check for sane coordinate input
     with raises(ValueError, match="Expected tripels"):
-        Structure(numbers, np.random.rand(7))
+        Structure(numbers, rng.random(7))
 
     # Construct real molecule
     mol = Structure(numbers, positions)
 
     # Try to update a structure with missmatched coordinates
     with raises(ValueError, match="Dimension missmatch for positions"):
-        mol.update(np.random.rand(7))
+        mol.update(rng.random(7))
 
     # Try to add a missmatched lattice
     with raises(ValueError, match="Invalid lattice provided"):
-        mol.update(positions, np.random.rand(7))
+        mol.update(positions, rng.random(7))
 
     # Try to update a structure with nuclear fusion coordinates
     with raises(RuntimeError, match="Too close interatomic distances found"):

--- a/python/mesonpep517.toml
+++ b/python/mesonpep517.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["meson-python", "cffi"]
+requires = ["meson-python", "cffi", "setuptools"]
 build-backend = "mesonpy"
 
 [project]


### PR DESCRIPTION
This *should* fix https://github.com/dftd3/simple-dftd3/issues/62.

`setuptools` is now a required build dependency for Python 3.12, see https://cffi.readthedocs.io/en/stable/whatsnew.html#v1-16-0.

It wasn't super clear to me how the wheels that land on PyPI are generated. To test this I downloaded the current source distribution, modified the `pyproject.toml` file, and tested that the installation works.
Someone needs to make sure that this also works with your workflow/in the CI.

The same patch should be applicable to [dftd4](https://github.com/dftd4/dftd4/blob/main/python/pyproject.toml#L2) and [tblite](https://github.com/dftd4/dftd4/blob/main/python/pyproject.toml#L2).

Linked issues for reference: https://github.com/tblite/tblite/issues/195 https://github.com/tblite/tblite/issues/198

While at it, I have also updated the usage of random calls to replace some deprecated function calls.

*I will have no access to the internet for the next two weeks and probably won't reply on this PR, sorry for that.*