### PR TITLE
Do not override grad_output at the end of arguments parsing

### DIFF
--- a/app/cli.f90
+++ b/app/cli.f90
@@ -389,7 +389,7 @@ subroutine get_run_arguments(config, list, start, error)
       return
    end if
 
-   if (config%grad.and. .not.config%json) then
+   if (config%grad.and. .not.config%json .and. .not.allocated(config%grad_output)) then
       config%grad_output = "dftd3.txt"
    end if
 


### PR DESCRIPTION
Fixes #84 

Now, it works as expected:
```
$ ./s-dftd3 CO.xyz --bj tpss --grad hdfgd
<...>
Virial:
--------------------------------------------------
      component           x          y          z
--------------------------------------------------
          x       0.000E+00  0.000E+00  0.000E+00
          y       0.000E+00  0.000E+00  0.000E+00
          z       0.000E+00  0.000E+00  1.711E-06
--------------------------------------------------

[Info] Dispersion energy written to .EDISP
[Info] Dispersion results written to 'hdfgd'
```