### PR TITLE
access parameters on Windows

### DIFF
--- a/python/dftd3/parameters.py
+++ b/python/dftd3/parameters.py
@@ -53,7 +53,12 @@ def get_data_file_name(base_name: str = "parameters.toml") -> str:
         dirname(__file__), "..", "..", "..", "..", "share", "s-dftd3", base_name
     )
     if not exists(data_file):
-        data_file = join(dirname(__file__), base_name)
+        # for Windows install layout
+        data_file = join(
+            dirname(__file__), "..", "..", "..", "Library", "share", "s-dftd3", base_name
+        )
+        if not exists(data_file):
+            data_file = join(dirname(__file__), base_name)
 
     return data_file
 


### PR DESCRIPTION
When the new D3 was picked up in QCEngine testing on Windows, it can't find the parameters file. Further below are traces from the conda-forge builds showing relative positioning on Linux and Windows. So I think this patch should fix up Windows, but it hasn't been tested.

```
dftd3-python              1.2.0           py312h2c12667_1    conda-forge
simple-dftd3              1.2.0                h28841b1_2    conda-forge
```
```
File "D:\a\QCEngine\QCEngine\qcengine\programs\empirical_dispersion_resources.py", line 1055, in <module>
    dashcoeff["d3bjatm"]["definitions"].update(_get_d3_definitions("bj"))
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\a\QCEngine\QCEngine\qcengine\programs\empirical_dispersion_resources.py", line 1052, in _get_d3_definitions
    for key, params in get_all_damping_params([dashlevel]).items()
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Miniconda\envs\test\Lib\site-packages\dftd3\parameters.py", line 119, in get_all_damping_params
    _data_base = load_data_base(data_file)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Miniconda\envs\test\Lib\site-packages\dftd3\parameters.py", line 40, in load_data_base
    with open(name) as fh:
         ^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Miniconda\\envs\\test\\Lib\\site-packages\\dftd3\\parameters.toml'
ans='C:\\Miniconda\\envs\\test\\Lib\\site-packages\\dftd3\\parameters.toml'
os.path.isfile(ans)=False
Error: Process completed with exit code 1.
```



a bit of the c-f build record for simple-dftd3 showing where the toml file is installed
```
024-11-01T09:24:00.7898852Z ?rw-rw-rw- 0/0       7885 2024-11-01 09:19:36 Library/include/s-dftd3/gcc-13.3.0/dftd3_param.mod 
2024-11-01T09:24:00.7902600Z ?rw-rw-rw- 0/0    3129144 2024-11-01 09:19:32 Library/lib/libs-dftd3.a 
2024-11-01T09:24:00.7903454Z ?rw-rw-rw- 0/0     134884 2024-11-01 09:19:28 Library/lib/libs-dftd3.dll.a 
2024-11-01T09:24:00.7904315Z ?rw-rw-rw- 0/0        361 2024-11-01 09:19:15 Library/lib/pkgconfig/s-dftd3.pc 
2024-11-01T09:24:00.7905217Z ?rw-rw-rw- 0/0      35149 2024-10-29 13:11:23 Library/share/licenses/s-dftd3/COPYING 
2024-11-01T09:24:00.7906129Z ?rw-rw-rw- 0/0       7652 2024-10-29 13:11:23 Library/share/licenses/s-dftd3/COPYING.LESSER 
2024-11-01T09:24:00.7907016Z ?rw-rw-rw- 0/0      30754 2024-10-29 13:11:23 Library/share/s-dftd3/parameters.toml 
...
2024-11-04T10:52:46.7506317Z ?rw-rw-rw- 0/0       4396 2024-11-04 10:48:06 Lib/site-packages/dftd3/parameters.py 
```

compare with linux
```
2024-11-01T09:20:39.0941483Z ?rwxrwxr-x 0/0    2507904 2024-11-01 09:19:20 lib/libs-dftd3.so.1.2.0 
2024-11-01T09:20:39.0941933Z ?rw-rw-r-- 0/0        557 2024-11-01 09:18:48 lib/pkgconfig/s-dftd3.pc 
2024-11-01T09:20:39.0942372Z ?rw-rw-r-- 0/0      35149 2024-10-29 13:11:23 share/licenses/s-dftd3/COPYING 
2024-11-01T09:20:39.0942940Z ?rw-rw-r-- 0/0       7652 2024-10-29 13:11:23 share/licenses/s-dftd3/COPYING.LESSER 
2024-11-01T09:20:39.0943816Z ?rw-rw-r-- 0/0       3209 2024-11-01 09:18:48 share/man/man1/s-dftd3.1 
2024-11-01T09:20:39.0944467Z ?rw-rw-r-- 0/0      30754 2024-10-29 13:11:23 share/s-dftd3/parameters.toml 
...
2024-11-04T10:50:02.0942810Z ?rw-rw-r-- 0/0       4396 2024-11-04 10:48:32 lib/python3.9/site-packages/dftd3/parameters.py
```