### PR TITLE
Add FHI-aims to users of s-dftd3 library list

### DIFF
--- a/doc/_static/references.bib
+++ b/doc/_static/references.bib
@@ -343,10 +343,10 @@ url  = {http://dx.doi.org/10.1039/D2CP03938A},
   date         = {2009},
   journal      = {Computer Physics Communications},
   title        = {Ab initio molecular simulations with numeric atom-centered orbitals},
-  doi          = {https://doi.org/10.1016/j.cpc.2009.06.022},
+  doi          = {10.1016/j.cpc.2009.06.022},
   number       = {11},
   pages        = {2175-2196},
-  url          = {https://www.sciencedirect.com/science/article/pii/S0010465509002033},
+  url          = {https://doi.org/10.1016/j.cpc.2009.06.022},
   volume       = {180},
 }
 

--- a/doc/_static/references.bib
+++ b/doc/_static/references.bib
@@ -338,3 +338,15 @@ url  = {http://dx.doi.org/10.1039/D2CP03938A},
     doi = {10.1021/acs.jctc.3c01203},
     URL = {https://doi.org/10.1021/acs.jctc.3c01203},
 }
+@article{blum2009,
+  author       = {Volker Blum and Ralf Gehrke and Felix Hanke and Paula Havu and Ville Havu and Xinguo Ren and Karsten Reuter and Matthias Scheffler},
+  date         = {2009},
+  journal      = {Computer Physics Communications},
+  title        = {Ab initio molecular simulations with numeric atom-centered orbitals},
+  doi          = {https://doi.org/10.1016/j.cpc.2009.06.022},
+  number       = {11},
+  pages        = {2175-2196},
+  url          = {https://www.sciencedirect.com/science/article/pii/S0010465509002033},
+  volume       = {180},
+}
+

--- a/doc/comparison.rst
+++ b/doc/comparison.rst
@@ -66,7 +66,8 @@ A list of projects currently using this DFT-D3 implementation is given here.
   Simple small molecular docking and conformation filtering tool.
 `MLAtom <https://github.com/dralgroup/mlatom>`_: (since 3.11.0)
   Platform for Machine Learning-Enhanced Computational Chemistry Simulations and Workflows.\ :footcite:`dral2024`
-
+`FHI-aims <https://fhi-aims.org/>`_: (since 240920)
+  All-electron electronic structure theory with numeric atom-centered orbitals.\ :footcite:`blum2009`
 
 If your project is using *s-dftd3* feel free to add your project to this list.
 


### PR DESCRIPTION
I recently implemented the simple-dftd3 library into FHI-aims (https://fhi-aims.org/), as of version 240920. Therefore I updated the "Users of this library" list in the docs to reflect this.