### PR TITLE
Update toml-f version 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,7 +267,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - run: pip3 install coverage
+    #- run: pip3 install coverage
 
     - name: Install dependencies
       uses: mamba-org/setup-micromamba@v1
@@ -275,6 +275,8 @@ jobs:
         environment-file: assets/ci/python-env.yaml
         create-args: |
           python=${{ matrix.python_v }}
+          
+    - run: python -m pip install --upgrade pip && python -m pip install coverage
 
     - name: Install GCC (OSX)
       if: ${{ contains(matrix.os, 'macos') }}
@@ -309,7 +311,7 @@ jobs:
         cp assets/parameters.toml python/dftd3
 
     - name: Install Python extension module (pip)
-      run: pip3 install . -vv
+      run: python3 -m pip install . -vv
       working-directory: python
       env:
         PKG_CONFIG_PATH: ${{ env.PKG_CONFIG_PATH }}:${{ env.DFTD3_PREFIX }}/lib/pkgconfig

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,7 +193,7 @@ jobs:
          --print-errorlogs
          --no-rebuild
          --num-processes 1
-         #--suite s-dftd3
+         --suite s-dftd3
          -t 2
          --benchmark
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       FC: ${{ matrix.compiler == 'intel' && 'ifort' || 'gfortran' }}
       CC: ${{ matrix.compiler == 'intel' && 'icc' || 'gcc' }}
       GCC_V: ${{ matrix.version }}
-      PYTHON_V: 3.8
+      PYTHON_V: 3.9
 
     steps:
     - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,7 @@ jobs:
          --print-errorlogs
          --no-rebuild
          --num-processes 1
-         --suite s-dftd3
+         #--suite s-dftd3
          -t 2
       env:
         OMP_NUM_THREADS: 1,2,1
@@ -193,7 +193,7 @@ jobs:
          --print-errorlogs
          --no-rebuild
          --num-processes 1
-         --suite s-dftd3
+         #--suite s-dftd3
          -t 2
          --benchmark
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         build: [meson, cmake, fpm]
         build-type: [debug]
         compiler: [gnu]
-        version: [10]
+        version: [12]
 
         include:
         - os: macos-15-intel
@@ -252,7 +252,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        gcc_v: [10]
+        gcc_v: [12]
         python_v: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,7 @@ jobs:
          --print-errorlogs
          --no-rebuild
          --num-processes 1
-         #--suite s-dftd3
+         --suite s-dftd3
          -t 2
       env:
         OMP_NUM_THREADS: 1,2,1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,11 @@ jobs:
         version: [10]
 
         include:
-        - os: macos-13
+        - os: macos-15-intel
           build: cmake
           build-type: debug
           compiler: gnu
-          version: 10
+          version: 14
 
         - os: ubuntu-latest
           build: meson
@@ -30,11 +30,11 @@ jobs:
           compiler: gnu
           version: 9
 
-        - os: macos-13
+        - os: macos-15-intel
           build: meson
           build-type: debug
           compiler: gnu
-          version: 10
+          version: 14
 
         - os: ubuntu-latest
           build: meson

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -69,7 +69,7 @@ jobs:
         os:
         - ubuntu-latest
         - windows-latest
-        - macos-13
+        - macos-15-intel
         - macos-14
 
     defaults:
@@ -100,7 +100,7 @@ jobs:
           CIBW_ARCHS_MACOS: ${{ matrix.os == 'macos-14' && 'arm64' || 'x86_64' }}
           CIBW_ENVIRONMENT_MACOS: >
              CC=gcc-14 CXX=g++-14 FC=gfortran-14
-             MACOSX_DEPLOYMENT_TARGET=${{ matrix.os == 'macos-14' && '14.0' || '13.0' }}
+             MACOSX_DEPLOYMENT_TARGET=${{ matrix.os == 'macos-14' && '14.0' || '15.0' }}
           CIBW_BEFORE_ALL_MACOS: brew install gcc@14
           CIBW_BEFORE_BUILD_WINDOWS: choco upgrade mingw && pip install delvewheel
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel show {wheel} && delvewheel repair -w {dest_dir} {wheel} --no-mangle-all"

--- a/assets/ci/build-env.yaml
+++ b/assets/ci/build-env.yaml
@@ -2,7 +2,7 @@ name: devel
 channels:
   - conda-forge
 dependencies:
-  - meson 0.58.0
+  - meson != 1.8.0
   - fpm
   - cmake
   - ninja

--- a/config/cmake/Findmctc-lib.cmake
+++ b/config/cmake/Findmctc-lib.cmake
@@ -17,7 +17,7 @@
 set(_lib "mctc-lib")
 set(_pkg "MCTCLIB")
 set(_url "https://github.com/grimme-lab/mctc-lib")
-set(_rev "v0.4.1")
+set(_rev "v0.5.0")
 
 if(NOT DEFINED "${_pkg}_FIND_METHOD")
   if(DEFINED "${PROJECT_NAME}-dependency-method")

--- a/config/cmake/Findmctc-lib.cmake
+++ b/config/cmake/Findmctc-lib.cmake
@@ -17,7 +17,7 @@
 set(_lib "mctc-lib")
 set(_pkg "MCTCLIB")
 set(_url "https://github.com/grimme-lab/mctc-lib")
-set(_rev "v0.5.0")
+set(_rev "v0.5.1")
 
 if(NOT DEFINED "${_pkg}_FIND_METHOD")
   if(DEFINED "${PROJECT_NAME}-dependency-method")

--- a/config/cmake/Findtoml-f.cmake
+++ b/config/cmake/Findtoml-f.cmake
@@ -17,7 +17,7 @@
 set(_lib "toml-f")
 set(_pkg "TOMLF")
 set(_url "https://github.com/toml-f/toml-f")
-set(_rev "v0.4.2")
+set(_rev "v0.4.3")
 
 if(NOT DEFINED "${_pkg}_FIND_METHOD")
   if(DEFINED "${PROJECT_NAME}-dependency-method")

--- a/config/meson.build
+++ b/config/meson.build
@@ -46,7 +46,7 @@ endif
 # Create the tool chain library as subproject
 mctc_dep = dependency(
   'mctc-lib',
-  version: '>=0.4.1',
+  version: '>=0.5.1',
   fallback: ['mctc-lib', 'mctc_dep'],
   default_options: ['default_library=static'],
 )
@@ -55,6 +55,7 @@ lib_deps += mctc_dep
 # Create the TOML Fortran library as subproject
 tomlf_dep = dependency(
   'toml-f',
+  version: '>=0.4.3',
   fallback: ['toml-f', 'tomlf_dep'],
   default_options: ['default_library=static'],
 )

--- a/fpm.toml
+++ b/fpm.toml
@@ -9,7 +9,7 @@ keywords = ["dispersion-correction", "quantum-chemistry"]
 
 [dependencies]
 mctc-lib.git = "https://github.com/grimme-lab/mctc-lib"
-mctc-lib.tag = "v0.5.0"
+mctc-lib.tag = "v0.5.1"
 
 [dev-dependencies]
 mstore.git = "https://github.com/grimme-lab/mstore"
@@ -21,6 +21,7 @@ auto-tests = false
 [[executable]]
 name = "s-dftd3"
 dependencies.toml-f.git = "https://github.com/toml-f/toml-f"
+dependencies.toml-f.tag = "v0.4.3"
 
 [[test]]
 name = "tester"

--- a/fpm.toml
+++ b/fpm.toml
@@ -9,7 +9,7 @@ keywords = ["dispersion-correction", "quantum-chemistry"]
 
 [dependencies]
 mctc-lib.git = "https://github.com/grimme-lab/mctc-lib"
-mctc-lib.tag = "v0.4.1"
+mctc-lib.tag = "v0.5.0"
 
 [dev-dependencies]
 mstore.git = "https://github.com/grimme-lab/mstore"

--- a/subprojects/mctc-lib.wrap
+++ b/subprojects/mctc-lib.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = mctc-lib
-url = https://github.com/thfroitzheim/mctc-lib
-revision = update-jonquil
+url = https://github.com/grimme-lab/mctc-lib
+revision = v0.5.1

--- a/subprojects/mctc-lib.wrap
+++ b/subprojects/mctc-lib.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = mctc-lib
 url = https://github.com/grimme-lab/mctc-lib
-revision = v0.4.1
+revision = v0.5.0

--- a/subprojects/mctc-lib.wrap
+++ b/subprojects/mctc-lib.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = mctc-lib
-url = https://github.com/grimme-lab/mctc-lib
-revision = v0.5.0
+url = https://github.com/thfroitzheim/mctc-lib
+revision = update-jonquil

--- a/subprojects/toml-f.wrap
+++ b/subprojects/toml-f.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = toml-f
 url = https://github.com/toml-f/toml-f
-revision = head
+revision = v0.4.3

--- a/subprojects/toml-f.wrap
+++ b/subprojects/toml-f.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = toml-f
 url = https://github.com/toml-f/toml-f
-revision = head
+revision = v0.4.2

--- a/subprojects/toml-f.wrap
+++ b/subprojects/toml-f.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = toml-f
 url = https://github.com/toml-f/toml-f
-revision = v0.4.2
+revision = head


### PR DESCRIPTION
As described in [mctc/#102](https://github.com/grimme-lab/mctc-lib/pull/102) there is an incompatibility between the toml-f versions in jonquil (head of toml-f) and simple-dftd3 (v0.4.2 of toml-f). I would recommend to first release toml-f and jonquil versions, which is why this is only a draft showing the problem. 

I also updated the macos runners to `macos-15-intel`  as `macos-13` will be [discontinued](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/). 