### PR TITLE
Fix `delete_gcp_api` pointer type

### DIFF
--- a/src/dftd3/api.f90
+++ b/src/dftd3/api.f90
@@ -964,7 +964,7 @@ end subroutine set_gcp_realspace_cutoff
 subroutine delete_gcp_api(vgcp) &
       & bind(C, name=namespace//"delete_gcp")
    type(c_ptr), intent(inout) :: vgcp
-   type(vp_error), pointer :: gcp
+   type(vp_gcp), pointer :: gcp
 
    if (c_associated(vgcp)) then
       call c_f_pointer(vgcp, gcp)


### PR DESCRIPTION
Hi devs!

The current deallocation function `delete_gcp_api` seems deleted a wrong type, potentially causing segfault. This simple PR can fix this problem.

This PR is also related to https://github.com/RESTGroup/dftd3-rs/issues/3 when we are testing our rust's dftd3 wrapper.

## Code to reproduce the problem

The following code can give segfault. the `GeometricCounterpoise` must be called a second time to reproduce this problem.
Perhaps different computing devices may give different behavior on this. The segfault at least happens to my PC.

```python
import numpy as np
from dftd3.interface import GeometricCounterpoise

numbers = np.array([1])
positions_bohr = np.array([[0.0, 0.0, 0.0]])

gcp = GeometricCounterpoise(numbers, positions_bohr, method='pbeh3c')
print(gcp.get_counterpoise(grad=False))
# Must run a second time to get the segfault
gcp = GeometricCounterpoise(numbers, positions_bohr, method='pbeh3c')
print(gcp.get_counterpoise(grad=False))
```