### PR TITLE
Add support for Z damping function

### DIFF
--- a/doc/api/c.rst
+++ b/doc/api/c.rst
@@ -296,6 +296,27 @@ Standard damping parameters like the rational damping are independent of the mol
 
    Load CSO damping parameters from internal storage
 
+.. c:function:: dftd3_param dftd3_new_z_damping(dftd3_error error, double s6, double s8, double s9, double a1, double alp);
+
+   :param error: Error handle
+   :param s6: Scaling of induced dipole-dipole dispersion energy
+   :param s8: Scaling of induced dipole-quadrupole dispersion energy
+   :param s9: Scaling of induced triple-dipole dispersion energy
+   :param a1: Atomic-number damping scale
+   :param alp: Exponent for the zero damping function (used for induced triple-dipole dispersion energy)
+   :returns: New damping parameter handle
+
+   Create new Z damping parameters
+
+.. c:function:: dftd3_param dftd3_load_z_damping(dftd3_error error, char* method, bool atm);
+
+   :param error: Error handle
+   :param method: Name of the method to load parameters for
+   :param atm: Use three-body dispersion
+   :returns: New damping parameter handle
+
+   Load Z damping parameters from internal storage
+
 .. c:function:: void dftd3_delete_param(dftd3_param* param);
 
    :param param: Dispersion parameter handle

--- a/doc/api/python.rst
+++ b/doc/api/python.rst
@@ -82,6 +82,13 @@ CSODampingParam
    :members:
 
 
+ZDampingParam
+~~~~~~~~~~~~~
+
+.. autoclass:: ZDampingParam
+   :members:
+
+
 QCSchema support
 ----------------
 

--- a/include/s-dftd3.h
+++ b/include/s-dftd3.h
@@ -249,6 +249,21 @@ dftd3_load_cso_damping(dftd3_error /* error */,
                        char* /* method */,
                        bool /* atm */) SDFTD3_API_SUFFIX__V_1_3;
 
+/// Create new Z damping parameters
+SDFTD3_API_ENTRY dftd3_param SDFTD3_API_CALL
+dftd3_new_z_damping(dftd3_error /* error */,
+                    double /* s6 */,
+                    double /* s8 */,
+                    double /* s9 */,
+                    double /* a1 */,
+                    double /* alp */) SDFTD3_API_SUFFIX__V_1_4;
+
+/// Load Z damping parameters from internal storage
+SDFTD3_API_ENTRY dftd3_param SDFTD3_API_CALL
+dftd3_load_z_damping(dftd3_error /* error */,
+                     char* /* method */,
+                     bool /* atm */) SDFTD3_API_SUFFIX__V_1_4;
+
 /// Delete damping parameters
 SDFTD3_API_ENTRY void SDFTD3_API_CALL
 dftd3_delete_param(dftd3_param* /* param */) SDFTD3_API_SUFFIX__V_0_2;

--- a/python/dftd3/ase.py
+++ b/python/dftd3/ase.py
@@ -114,6 +114,7 @@ from .interface import (
     ModifiedZeroDampingParam,
     OptimizedPowerDampingParam,
     CSODampingParam,
+    ZDampingParam,
 )
 from ase.calculators.calculator import (
     Calculator,
@@ -135,6 +136,7 @@ _damping_param = {
     "d3mzero": ModifiedZeroDampingParam,
     "d3op": OptimizedPowerDampingParam,
     "d3cso": CSODampingParam,
+    "d3z": ZDampingParam,
 }
 
 _inv_bohr = 1.0 / Bohr

--- a/python/dftd3/interface.py
+++ b/python/dftd3/interface.py
@@ -464,6 +464,44 @@ class CSODampingParam(DampingParam):
         )
 
 
+class ZDampingParam(DampingParam):
+    r"""
+    Z damping function for DFT-D3, based on the atomic-number damping form
+    proposed for XDM(Z).
+
+    No dedicated D3(Z) parameters are available; the internal parameter loader
+    uses XDM(Z) values for the supported functionals.
+    """
+
+    def __init__(self, **kwargs):
+        _rename_kwargs(kwargs, "alpha6", "alp")
+        DampingParam.__init__(self, **kwargs)
+
+    @staticmethod
+    def load_param(method: str, atm: bool = False) -> library.ParamHandle:
+        return library.load_z_damping(
+            method,
+            atm,
+        )
+
+    @staticmethod
+    def new_param(
+        *,
+        s6: float = 1.0,
+        s8: float = 1.0,
+        s9: float = 1.0,
+        a1: float,
+        alp: float = 14.0,
+    ) -> library.ParamHandle:
+        return library.new_z_damping(
+            s6,
+            s8,
+            s9,
+            a1,
+            alp,
+        )
+
+
 class DispersionModel(Structure):
     """
     .. Dispersion model

--- a/python/dftd3/library.py
+++ b/python/dftd3/library.py
@@ -262,6 +262,20 @@ def load_cso_damping(method: str, atm: bool) -> ParamHandle:
     )
 
 
+def new_z_damping(
+    s6: float, s8: float, s9: float, a1: float, alp: float
+) -> ParamHandle:
+    """Create new Z damping parameters"""
+    return ParamHandle.with_gc(
+        error_check(lib.dftd3_new_z_damping)(s6, s8, s9, a1, alp)
+    )
+
+
+def load_z_damping(method: str, atm: bool) -> ParamHandle:
+    """Load Z damping parameters from internal storage"""
+    return ParamHandle.with_gc(error_check(lib.dftd3_load_z_damping)(_char(method), atm))
+
+
 def update_structure(
     mol: StructureHandle, positions: np.ndarray, lattice: Optional[np.ndarray]
 ) -> None:

--- a/python/dftd3/pyscf.py
+++ b/python/dftd3/pyscf.py
@@ -37,6 +37,7 @@ from .interface import (
     ModifiedZeroDampingParam,
     OptimizedPowerDampingParam,
     CSODampingParam,
+    ZDampingParam,
 )
 
 GradientsBase = getattr(rhf_grad, "GradientsBase", rhf_grad.Gradients)
@@ -50,6 +51,7 @@ _damping_param = {
     "d3mzero": ModifiedZeroDampingParam,
     "d3op": OptimizedPowerDampingParam,
     "d3cso": CSODampingParam,
+    "d3z": ZDampingParam,
 }
 
 
@@ -72,11 +74,13 @@ class DFTD3Dispersion(lib.StreamObject):
         Optimized power damping function
     ``"d3cso"``
         CSO (C6-scaled only) damping function
+    ``"d3z"``
+        Z damping function
 
     Custom parameters can be provided with the `param` dictionary.
     The `param` dict contains the damping parameters, at least s8, a1 and a2
     must be provided for rational damping, while s8 and rs6 are required in case
-    of zero damping. For CSO damping, a1 must be provided.
+    of zero damping. For CSO and Z damping, a1 must be provided.
 
     Parameters for (modified) rational damping are:
 

--- a/python/dftd3/qcschema.py
+++ b/python/dftd3/qcschema.py
@@ -40,7 +40,7 @@ Supported keywords are
 ======================== =========== ============================================
 
 Allowed level hints are ``"d3bj"``, ``"d3zero"``, ``"d3bjm"``/``"d3mbj"``,
-``"d3mzero"``/``"d3zerom"``, ``"d3op"``, and ``"d3cso"``.
+``"d3mzero"``/``"d3zerom"``, ``"d3op"``, ``"d3cso"``, and ``"d3z"``.
 
 The params_tweaks dict contains the damping parameters, at least s8, a1 and a2
 must be provided for rational damping, while s8 and rs6 are required in case
@@ -143,6 +143,7 @@ from .interface import (
     ModifiedZeroDampingParam,
     OptimizedPowerDampingParam,
     CSODampingParam,
+    ZDampingParam,
 )
 from .library import get_api_version
 import numpy as np
@@ -182,6 +183,7 @@ _available_levels = [
     "d3mzero",
     "d3op",
     "d3cso",
+    "d3z",
 ]
 
 _damping_param = {
@@ -193,6 +195,7 @@ _damping_param = {
     "d3mzero": ModifiedZeroDampingParam,
     "d3op": OptimizedPowerDampingParam,
     "d3cso": CSODampingParam,
+    "d3z": ZDampingParam,
 }
 
 _clean_dashlevel = str.maketrans("", "", "()")

--- a/python/dftd3/test_interface.py
+++ b/python/dftd3/test_interface.py
@@ -21,6 +21,7 @@ from dftd3.interface import (
     ModifiedZeroDampingParam,
     ModifiedRationalDampingParam,
     OptimizedPowerDampingParam,
+    ZDampingParam,
     DispersionModel,
     GeometricCounterpoise,
 )
@@ -185,6 +186,19 @@ def test_optimized_power_damping_noargs() -> None:
         OptimizedPowerDampingParam(s8=1.0, a1=0.3, a2=4.2, bet=1.0, method="abc")
 
 
+def test_z_damping_noargs() -> None:
+    """Check constructor of Z damping parameters for insufficient arguments"""
+
+    with raises(TypeError):
+        ZDampingParam()
+
+    with raises(TypeError, match="a1"):
+        ZDampingParam(s8=1.0)
+
+    with raises(TypeError):
+        ZDampingParam(a1=200770.0, method="abc")
+
+
 @pytest.mark.parametrize("cls", [Structure, DispersionModel, GeometricCounterpoise])
 def test_structure(cls, numbers: np.ndarray, positions: np.ndarray) -> None:
     """check if the molecular structure data is working as expected."""
@@ -262,6 +276,12 @@ def test_b97d_d3_op(atm: bool, model: DispersionModel) -> None:
     res = model.get_dispersion(
         OptimizedPowerDampingParam(method="b97d", atm=atm), grad=False
     )
+    assert approx(res.get("energy")) == ref
+
+
+def test_pbe_d3_z(atm: bool, model: DispersionModel) -> None:
+    ref = -0.005741490224533363 if atm else -0.005841389688523762
+    res = model.get_dispersion(ZDampingParam(a1=200770.0, s9=1.0 if atm else 0.0), grad=False)
     assert approx(res.get("energy")) == ref
 
 

--- a/src/dftd3.f90
+++ b/src/dftd3.f90
@@ -25,10 +25,11 @@ module dftd3
       & new_optimizedpower_damping
    use dftd3_damping_rational, only : rational_damping_param, new_rational_damping
    use dftd3_damping_zero, only : zero_damping_param, new_zero_damping
+   use dftd3_damping_z, only : z_damping_param, new_z_damping
    use dftd3_model, only : d3_model, new_d3_model
    use dftd3_param, only : d3_param, get_rational_damping, get_zero_damping, &
       & get_mrational_damping, get_mzero_damping, get_optimizedpower_damping, &
-      & get_cso_damping
+      & get_cso_damping, get_z_damping
    use dftd3_version, only : get_dftd3_version
    implicit none
    private
@@ -40,12 +41,13 @@ module dftd3
    public :: get_rational_damping, get_zero_damping
    public :: get_mrational_damping, get_mzero_damping
    public :: get_optimizedpower_damping
-   public :: get_cso_damping
+   public :: get_cso_damping, get_z_damping
    public :: cso_damping_param, new_cso_damping
    public :: mzero_damping_param, new_mzero_damping
    public :: optimizedpower_damping_param, new_optimizedpower_damping
    public :: rational_damping_param, new_rational_damping
    public :: zero_damping_param, new_zero_damping
+   public :: z_damping_param, new_z_damping
    public :: d3_model, new_d3_model
    public :: get_dftd3_version
 

--- a/src/dftd3/api.f90
+++ b/src/dftd3/api.f90
@@ -30,13 +30,14 @@ module dftd3_api
       & new_optimizedpower_damping
    use dftd3_damping_rational, only : rational_damping_param, new_rational_damping
    use dftd3_damping_zero, only : zero_damping_param, new_zero_damping
+   use dftd3_damping_z, only : z_damping_param, new_z_damping
    use dftd3_damping, only : damping_param
    use dftd3_disp, only : get_dispersion, get_pairwise_dispersion
    use dftd3_gcp, only : gcp_param, get_gcp_param, get_geometric_counterpoise
    use dftd3_model, only : d3_model, new_d3_model
    use dftd3_param, only : d3_param, get_rational_damping, get_zero_damping, &
       & get_mrational_damping, get_mzero_damping, get_optimizedpower_damping, &
-      & get_cso_damping
+      & get_cso_damping, get_z_damping
    use dftd3_utils, only : wrap_to_central_cell
    use dftd3_version, only : get_dftd3_version
    implicit none
@@ -60,6 +61,7 @@ module dftd3_api
    public :: new_mrational_damping_api, load_mrational_damping_api
    public :: new_optimizedpower_damping_api, load_optimizedpower_damping_api
    public :: new_cso_damping_api, load_cso_damping_api
+   public :: new_z_damping_api, load_z_damping_api
    public :: delete_param_api
 
    public :: vp_gcp
@@ -782,6 +784,73 @@ function load_cso_damping_api(verror, charptr, atm) &
    vparam = c_loc(param)
 
 end function load_cso_damping_api
+
+
+!> Create new Z damping parameters
+function new_z_damping_api(verror, s6, s8, s9, a1, alp) &
+      & result(vparam) &
+      & bind(C, name=namespace//"new_z_damping")
+   type(c_ptr), value :: verror
+   type(vp_error), pointer :: error
+   real(c_double), value, intent(in) :: s6
+   real(c_double), value, intent(in) :: s8
+   real(c_double), value, intent(in) :: s9
+   real(c_double), value, intent(in) :: a1
+   real(c_double), value, intent(in) :: alp
+   type(c_ptr) :: vparam
+   type(z_damping_param), allocatable :: tmp
+   type(vp_param), pointer :: param
+
+   vparam = c_null_ptr
+
+   if (.not.c_associated(verror)) return
+   call c_f_pointer(verror, error)
+
+   allocate(tmp)
+   call new_z_damping(tmp, d3_param(s6=s6, s8=s8, s9=s9, a1=a1, &
+      & a2=0.0_wp, alp=alp))
+
+   allocate(param)
+   call move_alloc(tmp, param%ptr)
+   vparam = c_loc(param)
+
+end function new_z_damping_api
+
+
+!> Load Z damping parameters from internal storage
+function load_z_damping_api(verror, charptr, atm) &
+      & result(vparam) &
+      & bind(C, name=namespace//"load_z_damping")
+   type(c_ptr), value :: verror
+   type(vp_error), pointer :: error
+   character(kind=c_char), intent(in) :: charptr(*)
+   logical(c_bool), value, intent(in) :: atm
+   character(len=:, kind=c_char), allocatable :: method
+   type(c_ptr) :: vparam
+   type(z_damping_param), allocatable :: tmp
+   type(vp_param), pointer :: param
+   type(d3_param) :: inp
+   real(wp), allocatable :: s9
+
+   vparam = c_null_ptr
+
+   if (.not.c_associated(verror)) return
+   call c_f_pointer(verror, error)
+
+   call c_f_character(charptr, method)
+
+   if (atm) s9 = 1.0_wp
+   call get_z_damping(inp, method, error%ptr, s9)
+   if (allocated(error%ptr)) return
+
+   allocate(tmp)
+   call new_z_damping(tmp, inp)
+
+   allocate(param)
+   call move_alloc(tmp, param%ptr)
+   vparam = c_loc(param)
+
+end function load_z_damping_api
 
 
 !> Delete damping parameters

--- a/src/dftd3/citation.f90
+++ b/src/dftd3/citation.f90
@@ -22,6 +22,7 @@ module dftd3_citation
    public :: citation_type, author_name, new_citation, is_citation_present
    public :: format_bibtex, get_citation, same_citation
    public :: doi_dftd3_0, doi_dftd3_bj, doi_dftd3_m, doi_dftd3_op, doi_dftd3_cso, &
+      & doi_z_damping, &
       & doi_gmtkn30_0, doi_gmtkn30_bj, doi_gmtkn55, doi_dsd, doi_dsdpbep86, &
       & doi_drpa, doi_revdsd, doi_pw91_d3, doi_r2scan_d4, doi_scan_d3, &
       & doi_pbeh3c, doi_hse3c, doi_b973c, doi_hf3c, doi_gcp, doi_d3pbc, &
@@ -61,6 +62,7 @@ module dftd3_citation
       & doi_dftd3_bj = "10.1002/jcc.21759", &
       & doi_dftd3_m = "10.1021/acs.jpclett.6b00780", &
       & doi_dftd3_op = "10.1021/acs.jctc.7b00176", &
+      & doi_z_damping = "10.1063/5.0207682", &
       & doi_gmtkn30_0 = "10.1021/ct100466k", &
       & doi_gmtkn30_bj = "10.1039/c0cp02984j", &
       & doi_gmtkn55 = "10.1039/c7cp04913g", &
@@ -262,6 +264,33 @@ pure function get_citation(doi) result(citation)
          volume="13", &
          pages="2043-2052", &
          year="2017" &
+      )
+
+   case(doi_dftd3_cso)
+      citation = new_citation( &
+         doi=doi, &
+         title="Reformulation of the D3(Becke-Johnson) Dispersion Correction "// &
+         & "without Resorting to Higher than C6 Dispersion Coefficients", &
+         author=[ &
+         & author_name('Heiner Schr{\"o}der'), &
+         & author_name("Jens Creon"), &
+         & author_name("Tobias Schwabe")], &
+         journal="J. Chem. Theory Comput.", &
+         volume="11", &
+         pages="3163--3170", &
+         year="2015" &
+      )
+
+   case(doi_z_damping)
+      citation = new_citation( &
+         doi=doi, &
+         title="A remarkably simple dispersion damping scheme and the DH24 double hybrid density functional", &
+         author=[ &
+         & author_name("Axel D. Becke")], &
+         journal="J. Chem. Phys.", &
+         volume="160", &
+         pages="204118", &
+         year="2024" &
       )
       
    case(doi_gmtkn30_0)
@@ -675,21 +704,6 @@ pure function get_citation(doi) result(citation)
          volume="2506.14665", &
          pages="2506.14665", &
          year="2025" &
-      )
-
-   case(doi_dftd3_cso)
-      citation = new_citation( &
-         doi=doi, &
-         title="Reformulation of the D3(Becke-Johnson) Dispersion Correction "// &
-         & "without Resorting to Higher than C6 Dispersion Coefficients", &
-         author=[ &
-         & author_name('Heiner Schr{\"o}der'), &
-         & author_name("Jens Creon"), &
-         & author_name("Tobias Schwabe")], &
-         journal="J. Chem. Theory Comput.", &
-         volume="11", &
-         pages="3163--3170", &
-         year="2015" &
       )
    end select
 end function get_citation

--- a/src/dftd3/damping/CMakeLists.txt
+++ b/src/dftd3/damping/CMakeLists.txt
@@ -23,6 +23,7 @@ list(
   "${dir}/mzero.f90"
   "${dir}/optimizedpower.f90"
   "${dir}/rational.f90"
+  "${dir}/z.f90"
   "${dir}/zero.f90"
 )
 

--- a/src/dftd3/damping/meson.build
+++ b/src/dftd3/damping/meson.build
@@ -20,5 +20,6 @@ srcs += files(
   'mzero.f90',
   'optimizedpower.f90',
   'rational.f90',
+  'z.f90',
   'zero.f90',
 )

--- a/src/dftd3/damping/z.f90
+++ b/src/dftd3/damping/z.f90
@@ -1,0 +1,529 @@
+! This file is part of s-dftd3.
+! SPDX-Identifier: LGPL-3.0-or-later
+!
+! s-dftd3 is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! s-dftd3 is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with s-dftd3.  If not, see <https://www.gnu.org/licenses/>.
+
+module dftd3_damping_z
+   use dftd3_cutoff, only : smooth_cutoff
+   use dftd3_damping, only : damping_param
+   use dftd3_damping_atm, only : get_atm_dispersion, get_atm_pairwise_dispersion
+   use dftd3_param, only : d3_param
+   use mctc_env, only : wp
+   use mctc_io, only : structure_type
+   implicit none
+
+   public :: z_damping_param, new_z_damping
+
+
+   !> Z damping model
+   type, extends(damping_param) :: z_damping_param
+      real(wp) :: s6
+      real(wp) :: s8
+      real(wp) :: s9
+      real(wp) :: a1
+      real(wp) :: alp
+   contains
+
+      !> Evaluate pairwise dispersion energy expression
+      procedure :: get_dispersion2_impl => get_dispersion2
+
+      !> Evaluate ATM three-body dispersion energy expression
+      procedure :: get_dispersion3_impl => get_dispersion3
+
+      !> Evaluate pairwise representation of additive dispersion energy
+      procedure :: get_pairwise_dispersion2_impl => get_pairwise_dispersion2
+
+      !> Evaluate pairwise representation of non-additive dispersion energy
+      procedure :: get_pairwise_dispersion3_impl => get_pairwise_dispersion3
+
+   end type z_damping_param
+
+
+   real(wp), parameter :: rs9 = 4.0_wp/3.0_wp
+
+
+contains
+
+
+!> Create new Z damping model
+subroutine new_z_damping(self, param)
+
+   !> Z damping parameters
+   type(z_damping_param), intent(out) :: self
+
+   !> Parameters
+   type(d3_param), intent(in) :: param
+
+   self%s6 = param%s6
+   self%s8 = param%s8
+   self%s9 = param%s9
+   self%a1 = param%a1
+   self%alp = param%alp
+
+end subroutine new_z_damping
+
+
+!> Evaluation of the dispersion energy expression
+subroutine get_dispersion2(self, mol, trans, cutoff, width, rvdw, r4r2, c6, dc6dcn, &
+      & energy, dEdcn, gradient, sigma)
+
+   !> Damping parameters
+   class(z_damping_param), intent(in) :: self
+
+   !> Molecular structure data
+   class(structure_type), intent(in) :: mol
+
+   !> Lattice points
+   real(wp), intent(in) :: trans(:, :)
+
+   !> Real space cutoff
+   real(wp), intent(in) :: cutoff
+
+   !> Width of smooth cutoff
+   real(wp), intent(in) :: width
+
+   !> Van-der-Waals radii for damping function
+   real(wp), intent(in) :: rvdw(:, :)
+
+   !> Expectation values for C8 extrapolation
+   real(wp), intent(in) :: r4r2(:)
+
+   !> C6 coefficients for all atom pairs.
+   real(wp), intent(in) :: c6(:, :)
+
+   !> Derivative of the C6 w.r.t. the coordination number
+   real(wp), intent(in), optional :: dc6dcn(:, :)
+
+   !> Dispersion energy
+   real(wp), intent(inout) :: energy(:)
+
+   !> Derivative of the energy w.r.t. the coordination number
+   real(wp), intent(inout), optional :: dEdcn(:)
+
+   !> Dispersion gradient
+   real(wp), intent(inout), optional :: gradient(:, :)
+
+   !> Dispersion virial
+   real(wp), intent(inout), optional :: sigma(:, :)
+
+   logical :: grad
+
+   if (abs(self%s6) < epsilon(1.0_wp) .and. abs(self%s8) < epsilon(1.0_wp)) return
+   grad = present(dc6dcn) .and. present(dEdcn) .and. present(gradient) &
+      & .and. present(sigma)
+
+   if (grad) then
+      call get_dispersion_derivs(self, mol, trans, cutoff, width, rvdw, r4r2, c6, dc6dcn, &
+         & energy, dEdcn, gradient, sigma)
+   else
+      call get_dispersion_energy(self, mol, trans, cutoff, width, rvdw, r4r2, c6, energy)
+   end if
+
+end subroutine get_dispersion2
+
+
+!> Evaluation of the dispersion energy expression
+subroutine get_dispersion_energy(self, mol, trans, cutoff, width, rvdw, r4r2, c6, energy)
+
+   !> Damping parameters
+   class(z_damping_param), intent(in) :: self
+
+   !> Molecular structure data
+   class(structure_type), intent(in) :: mol
+
+   !> Lattice points
+   real(wp), intent(in) :: trans(:, :)
+
+   !> Real space cutoff
+   real(wp), intent(in) :: cutoff
+
+   !> Width of smooth cutoff
+   real(wp), intent(in) :: width
+
+   !> Van-der-Waals radii for damping function
+   real(wp), intent(in) :: rvdw(:, :)
+
+   !> Expectation values for C8 extrapolation
+   real(wp), intent(in) :: r4r2(:)
+
+   !> C6 coefficients for all atom pairs.
+   real(wp), intent(in) :: c6(:, :)
+
+   !> Dispersion energy
+   real(wp), intent(inout) :: energy(:)
+
+   integer :: iat, jat, izp, jzp, jtr
+   real(wp) :: vec(3), r2, r1, cutoff2, r0ij, rrij, c6ij, t6, t8, edisp, dE
+   real(wp) :: sw, dswdr
+   real(wp) :: r0ij2, r0ij6, r0ij8, r4
+
+   ! Thread-private array for reduction
+   ! Set to 0 explicitly as the shared variants are potentially non-zero (inout)
+   real(wp), allocatable :: energy_local(:)
+
+   cutoff2 = cutoff*cutoff
+
+   !$omp parallel default(none) &
+   !$omp shared(mol, self, c6, trans, cutoff2, cutoff, width, r4r2) &
+   !$omp private(iat, jat, izp, jzp, jtr, vec, r2, r1, r0ij, rrij, c6ij, t6, &
+   !$omp& t8, edisp, dE, r0ij2, r0ij6, r0ij8, r4, sw, dswdr) &
+   !$omp shared(energy) &
+   !$omp private(energy_local)
+   allocate(energy_local(size(energy, 1)), source=0.0_wp)
+   !$omp do schedule(runtime)
+   do iat = 1, mol%nat
+      izp = mol%id(iat)
+      do jat = 1, iat
+         jzp = mol%id(jat)
+         rrij = 3*r4r2(izp)*r4r2(jzp)
+         r0ij = self%a1 / (izp + jzp)
+         c6ij = c6(jat, iat)
+         do jtr = 1, size(trans, 2)
+            vec(:) = mol%xyz(:, iat) - (mol%xyz(:, jat) + trans(:, jtr))
+            r2 = vec(1)*vec(1) + vec(2)*vec(2) + vec(3)*vec(3)
+            if (r2 > cutoff2 .or. r2 < epsilon(1.0_wp)) cycle
+            r1 = sqrt(r2)
+            call smooth_cutoff(r1, cutoff, width, sw, dswdr)
+
+            r4 = r2 * r2
+            t6 = 1.0_wp/(r4 * r2 + r0ij * c6ij)
+            t8 = 1.0_wp/(r4 * r4 + r0ij * c6ij * rrij)
+
+            edisp = sw * (self%s6*t6 + self%s8*rrij*t8)
+
+            dE = -c6ij*edisp * 0.5_wp
+
+            energy_local(iat) = energy_local(iat) + dE
+            if (iat /= jat) then
+               energy_local(jat) = energy_local(jat) + dE
+            end if
+         end do
+      end do
+   end do
+   !$omp end do
+   !$omp critical (get_dispersion_energy_)
+   energy(:) = energy(:) + energy_local(:)
+   !$omp end critical (get_dispersion_energy_)
+   deallocate(energy_local)
+   !$omp end parallel
+
+end subroutine get_dispersion_energy
+
+
+!> Evaluation of the dispersion energy expression
+subroutine get_dispersion_derivs(self, mol, trans, cutoff, width, rvdw, r4r2, c6, dc6dcn, &
+      & energy, dEdcn, gradient, sigma)
+
+   !> Damping parameters
+   class(z_damping_param), intent(in) :: self
+
+   !> Molecular structure data
+   class(structure_type), intent(in) :: mol
+
+   !> Lattice points
+   real(wp), intent(in) :: trans(:, :)
+
+   !> Real space cutoff
+   real(wp), intent(in) :: cutoff
+
+   !> Width of smooth cutoff
+   real(wp), intent(in) :: width
+
+   !> Van-der-Waals radii for damping function
+   real(wp), intent(in) :: rvdw(:, :)
+
+   !> Expectation values for C8 extrapolation
+   real(wp), intent(in) :: r4r2(:)
+
+   !> C6 coefficients for all atom pairs.
+   real(wp), intent(in) :: c6(:, :)
+
+   !> Derivative of the C6 w.r.t. the coordination number
+   real(wp), intent(in) :: dc6dcn(:, :)
+
+   !> Dispersion energy
+   real(wp), intent(inout) :: energy(:)
+
+   !> Derivative of the energy w.r.t. the coordination number
+   real(wp), intent(inout) :: dEdcn(:)
+
+   !> Dispersion gradient
+   real(wp), intent(inout) :: gradient(:, :)
+
+   !> Dispersion virial
+   real(wp), intent(inout) :: sigma(:, :)
+
+   integer :: iat, jat, izp, jzp, jtr, ic, jc
+   real(wp) :: vec(3), r2, r1, cutoff2, r0ij, rrij, c6ij, t6, t8, d6, d8
+   real(wp) :: edisp0, gdisp0, edisp, gdisp, sw, dswdr
+   real(wp) :: dE, dG(3), dS(3, 3), dEdc6
+   real(wp) :: r0ij2, r0ij6, r0ij8, r4
+
+   ! Thread-private arrays for reduction
+   ! Set to 0 explicitly as the shared variants are potentially non-zero (inout)
+   real(wp), allocatable :: energy_local(:)
+   real(wp), allocatable :: dEdcn_local(:)
+   real(wp), allocatable :: gradient_local(:, :)
+   real(wp), allocatable :: sigma_local(:, :)
+
+   cutoff2 = cutoff*cutoff
+
+   !$omp parallel default(none) &
+   !$omp shared(mol, self, c6, dc6dcn, trans, cutoff2, cutoff, width, r4r2) &
+   !$omp private(iat, jat, izp, jzp, jtr, ic, jc, vec, r2, r1, r0ij, rrij, c6ij, &
+   !$omp& t6, t8, d6, d8, edisp0, gdisp0, edisp, gdisp, dE, dG, dS, dEdc6, &
+   !$omp& r0ij2, r0ij6, r0ij8, r4, sw, dswdr) &
+   !$omp shared(energy, gradient, sigma, dEdcn) &
+   !$omp private(energy_local, gradient_local, sigma_local, dEdcn_local)
+   allocate(energy_local(size(energy, 1)), source=0.0_wp)
+   allocate(dEdcn_local(size(dEdcn, 1)), source=0.0_wp)
+   allocate(gradient_local(size(gradient, 1), size(gradient, 2)), source=0.0_wp)
+   allocate(sigma_local(size(sigma, 1), size(sigma, 2)), source=0.0_wp)
+   !$omp do schedule(runtime)
+   do iat = 1, mol%nat
+      izp = mol%id(iat)
+      do jat = 1, iat
+         jzp = mol%id(jat)
+         rrij = 3*r4r2(izp)*r4r2(jzp)
+         r0ij = self%a1 / (izp + jzp)
+         c6ij = c6(jat, iat)
+         do jtr = 1, size(trans, 2)
+            vec(:) = mol%xyz(:, iat) - (mol%xyz(:, jat) + trans(:, jtr))
+            r2 = vec(1)*vec(1) + vec(2)*vec(2) + vec(3)*vec(3)
+            if (r2 > cutoff2 .or. r2 < epsilon(1.0_wp)) cycle
+            r1 = sqrt(r2)
+            call smooth_cutoff(r1, cutoff, width, sw, dswdr)
+
+            r4 = r2 * r2
+            t6 = 1.0_wp/(r4 * r2 + r0ij * c6ij)
+            t8 = 1.0_wp/(r4 * r4 + r0ij * c6ij * rrij)
+
+            d6 = -6*r4*t6*t6
+            d8 = -8*r4*r2*t8*t8
+
+            edisp0 = self%s6*t6 + self%s8*rrij*t8
+            gdisp0 = self%s6*d6 + self%s8*rrij*d8
+            edisp = sw * edisp0
+            gdisp = sw * gdisp0 + dswdr * edisp0 / r1
+
+            dE = -c6ij*edisp * 0.5_wp
+            dEdc6 = -sw * (self%s6*r4*r2*t6*t6 + self%s8*rrij*r4*r4*t8*t8)
+            dG(:) = -c6ij*gdisp*vec
+            do ic = 1, 3
+               do jc = 1, 3
+                  dS(ic, jc) = dG(ic) * vec(jc) * 0.5_wp
+               end do
+            end do
+
+            energy_local(iat) = energy_local(iat) + dE
+            dEdcn_local(iat) = dEdcn_local(iat) + dc6dcn(iat, jat) * dEdc6
+            sigma_local(:, :) = sigma_local + dS
+            if (iat /= jat) then
+               energy_local(jat) = energy_local(jat) + dE
+               dEdcn_local(jat) = dEdcn_local(jat) + dc6dcn(jat, iat) * dEdc6
+               gradient_local(:, iat) = gradient_local(:, iat) + dG
+               gradient_local(:, jat) = gradient_local(:, jat) - dG
+               sigma_local(:, :) = sigma_local + dS
+            end if
+         end do
+      end do
+   end do
+   !$omp end do
+   !$omp critical (get_dispersion_derivs_)
+   energy(:) = energy(:) + energy_local(:)
+   dEdcn(:) = dEdcn(:) + dEdcn_local(:)
+   gradient(:, :) = gradient(:, :) + gradient_local(:, :)
+   sigma(:, :) = sigma(:, :) + sigma_local(:, :)
+   !$omp end critical (get_dispersion_derivs_)
+   deallocate(energy_local)
+   deallocate(dEdcn_local)
+   deallocate(gradient_local)
+   deallocate(sigma_local)
+   !$omp end parallel
+
+end subroutine get_dispersion_derivs
+
+
+!> Evaluation of the dispersion energy expression
+subroutine get_dispersion3(self, mol, trans, cutoff, width, rvdw, r4r2, c6, dc6dcn, &
+      & energy, dEdcn, gradient, sigma)
+
+   !> Damping parameters
+   class(z_damping_param), intent(in) :: self
+
+   !> Molecular structure data
+   class(structure_type), intent(in) :: mol
+
+   !> Lattice points
+   real(wp), intent(in) :: trans(:, :)
+
+   !> Real space cutoff
+   real(wp), intent(in) :: cutoff
+
+   !> Width of smooth cutoff
+   real(wp), intent(in) :: width
+
+   !> Van-der-Waals radii for damping function
+   real(wp), intent(in) :: rvdw(:, :)
+
+   !> Expectation values for C8 extrapolation
+   real(wp), intent(in) :: r4r2(:)
+
+   !> C6 coefficients for all atom pairs.
+   real(wp), intent(in) :: c6(:, :)
+
+   !> Derivative of the C6 w.r.t. the coordination number
+   real(wp), intent(in), optional :: dc6dcn(:, :)
+
+   !> Dispersion energy
+   real(wp), intent(inout) :: energy(:)
+
+   !> Derivative of the energy w.r.t. the coordination number
+   real(wp), intent(inout), optional :: dEdcn(:)
+
+   !> Dispersion gradient
+   real(wp), intent(inout), optional :: gradient(:, :)
+
+   !> Dispersion virial
+   real(wp), intent(inout), optional :: sigma(:, :)
+
+   call get_atm_dispersion(mol, trans, cutoff, width, self%s9, rs9, self%alp+2, &
+      & rvdw, c6, dc6dcn, energy, dEdcn, gradient, sigma)
+
+end subroutine get_dispersion3
+
+
+!> Evaluation of the dispersion energy expression projected on atomic pairs
+subroutine get_pairwise_dispersion2(self, mol, trans, cutoff, width, rvdw, r4r2, c6, energy)
+
+   !> Damping parameters
+   class(z_damping_param), intent(in) :: self
+
+   !> Molecular structure data
+   class(structure_type), intent(in) :: mol
+
+   !> Lattice points
+   real(wp), intent(in) :: trans(:, :)
+
+   !> Real space cutoff
+   real(wp), intent(in) :: cutoff
+
+   !> Width of smooth cutoff
+   real(wp), intent(in) :: width
+
+   !> Van-der-Waals radii for damping function
+   real(wp), intent(in) :: rvdw(:, :)
+
+   !> Expectation values for r4 over r2 operator
+   real(wp), intent(in) :: r4r2(:)
+
+   !> C6 coefficients for all atom pairs.
+   real(wp), intent(in) :: c6(:, :)
+
+   !> Dispersion energy
+   real(wp), intent(inout) :: energy(:, :)
+
+   integer :: iat, jat, izp, jzp, jtr
+   real(wp) :: vec(3), r2, r1, cutoff2, r0ij, rrij, c6ij, t6, t8, edisp, dE
+   real(wp) :: sw, dswdr
+
+   ! Thread-private array for reduction
+   ! Set to 0 explicitly as the shared variants are potentially non-zero (inout)
+   real(wp), allocatable :: energy_local(:, :)
+
+   cutoff2 = cutoff*cutoff
+
+   !$omp parallel default(none) &
+   !$omp shared(mol, self, c6, trans, cutoff2, cutoff, width, r4r2) &
+   !$omp private(iat, jat, izp, jzp, jtr, vec, r2, r1, r0ij, rrij, c6ij, t6, &
+   !$omp& t8, edisp, dE, sw, dswdr) &
+   !$omp shared(energy) &
+   !$omp private(energy_local)
+   allocate(energy_local(size(energy, 1), size(energy, 2)), source=0.0_wp)
+   !$omp do schedule(runtime)
+   do iat = 1, mol%nat
+      izp = mol%id(iat)
+      do jat = 1, iat
+         jzp = mol%id(jat)
+         rrij = 3*r4r2(izp)*r4r2(jzp)
+         r0ij = self%a1 / (izp + jzp)
+         c6ij = c6(jat, iat)
+         do jtr = 1, size(trans, 2)
+            vec(:) = mol%xyz(:, iat) - (mol%xyz(:, jat) + trans(:, jtr))
+            r2 = vec(1)*vec(1) + vec(2)*vec(2) + vec(3)*vec(3)
+            if (r2 > cutoff2 .or. r2 < epsilon(1.0_wp)) cycle
+            r1 = sqrt(r2)
+            call smooth_cutoff(r1, cutoff, width, sw, dswdr)
+
+            t6 = 1.0_wp/(r2**3 + r0ij * c6ij)
+            t8 = 1.0_wp/(r2**4 + r0ij * c6ij * rrij)
+
+            edisp = sw * (self%s6*t6 + self%s8*rrij*t8)
+
+            dE = -c6ij*edisp * 0.5_wp
+
+            energy_local(jat, iat) = energy_local(jat, iat) + dE
+            if (iat /= jat) then
+               energy_local(iat, jat) = energy_local(iat, jat) + dE
+            end if
+         end do
+      end do
+   end do
+   !$omp end do
+   !$omp critical (get_pairwise_dispersion2_)
+   energy(:, :) = energy(:, :) + energy_local(:, :)
+   !$omp end critical (get_pairwise_dispersion2_)
+   deallocate(energy_local)
+   !$omp end parallel
+
+end subroutine get_pairwise_dispersion2
+
+
+!> Evaluation of the dispersion energy expression
+subroutine get_pairwise_dispersion3(self, mol, trans, cutoff, width, rvdw, r4r2, c6, energy)
+
+   !> Damping parameters
+   class(z_damping_param), intent(in) :: self
+
+   !> Molecular structure data
+   class(structure_type), intent(in) :: mol
+
+   !> Lattice points
+   real(wp), intent(in) :: trans(:, :)
+
+   !> Real space cutoff
+   real(wp), intent(in) :: cutoff
+
+   !> Width of smooth cutoff
+   real(wp), intent(in) :: width
+
+   !> Van-der-Waals radii for damping function
+   real(wp), intent(in) :: rvdw(:, :)
+
+   !> Expectation values for r4 over r2 operator
+   real(wp), intent(in) :: r4r2(:)
+
+   !> C6 coefficients for all atom pairs.
+   real(wp), intent(in) :: c6(:, :)
+
+   !> Dispersion energy
+   real(wp), intent(inout) :: energy(:, :)
+
+   call get_atm_pairwise_dispersion(mol, trans, cutoff, width, self%s9, rs9, self%alp+2, &
+      & rvdw, c6, energy)
+
+end subroutine get_pairwise_dispersion3
+
+
+end module dftd3_damping_z

--- a/src/dftd3/param.f90
+++ b/src/dftd3/param.f90
@@ -18,7 +18,7 @@ module dftd3_param
    use mctc_env, only : wp, error_type, fatal_error
    use dftd3_citation, only : citation_type, author_name, new_citation, &
       & get_citation, doi_dftd3_0, doi_dftd3_bj, doi_dftd3_m, doi_dftd3_op, &
-      & doi_dftd3_cso, &
+      & doi_dftd3_cso, doi_z_damping, &
       & doi_gmtkn30_0, doi_gmtkn30_bj, doi_gmtkn55, doi_dsd, doi_dsdpbep86, &
       & doi_drpa, doi_revdsd, doi_pw91_d3, doi_r2scan_d4, doi_scan_d3, &
       & doi_pbeh3c, doi_hse3c, doi_b973c, doi_hf3c, doi_gcp, doi_d3pbc, &
@@ -31,6 +31,7 @@ module dftd3_param
    public :: get_mrational_damping, get_mzero_damping
    public :: get_optimizedpower_damping
    public :: get_cso_damping
+   public :: get_z_damping
 
 
    type :: d3_param
@@ -85,7 +86,7 @@ module dftd3_param
          & p_dsd_xb95_df, p_dsd_b98_df, p_dsd_bmk_df, p_dsd_thcth_df, &
          & p_dsd_hcth407_df, p_dod_svwn5_df, p_dod_blyp_df, p_dod_pbe_df, &
          & p_dod_pbep86_df, p_dod_pbeb95_df, p_dod_hsep86_df, p_dod_pbehb95_df, &
-         & p_cf22d_df, p_skala_df
+         & p_cf22d_df, p_skala_df, p_b86bpbe_df, p_b86bpbe0_df
    end enum
 
 contains
@@ -121,6 +122,8 @@ function get_method_id(method) result(id)
    case("b3lyp/631gd"); id = p_b3lyp_631gd_df
    case("b3p", "b3p86"); id = p_b3p_df
    case("b3pw91"); id = p_b3pw91_df
+   case("b86bpbe"); id = p_b86bpbe_df
+   case("b86bpbe0"); id = p_b86bpbe0_df
    case("b971"); id = p_b97_1_df
    case("b972"); id = p_b97_2_df
    case("b97d"); id = p_b97d_df
@@ -1287,6 +1290,39 @@ subroutine get_cso_damping(param, method, error, s9, citation)
    end if
 
 end subroutine get_cso_damping
+
+
+!> Load Z damping parameters from internal storage
+subroutine get_z_damping(param, method, error, s9, citation)
+
+   !> Loaded parameter record
+   type(d3_param), intent(out) :: param
+
+   !> Name of the method to look up
+   character(len=*), intent(in) :: method
+
+   !> Overwrite s9
+   real(wp), intent(in), optional :: s9
+
+   !> Citation information
+   type(citation_type), intent(out), optional :: citation
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   select case(get_method_id(method))
+   case default
+      call fatal_error(error, "No entry for '"//method//"' present")
+      return
+   end select
+
+   if (present(citation)) citation = get_citation(doi_z_damping)
+
+   if (present(s9)) then
+      param%s9 = s9
+   end if
+
+end subroutine get_z_damping
 
 
 !> Convert string to lower case

--- a/test/api/api-test.c
+++ b/test/api/api-test.c
@@ -315,6 +315,28 @@ test_d3 (void) {
    if (dftd3_check_error(error)) {return 1;}
    dftd3_delete(param);
 
+   // PBE-D3(Z)
+   param = dftd3_new_z_damping(error, 1.0, 1.0, 0.0, 200770.0, 14.0);
+   if (dftd3_check_error(error)) {return 1;}
+   assert(!!param);
+   dftd3_get_dispersion(error, mol, disp, param, &energy, NULL, NULL);
+   if (dftd3_check_error(error)) {return 1;}
+   dftd3_get_dispersion(error, mol, disp, param, &energy, gradient, sigma);
+   if (dftd3_check_error(error)) {return 1;}
+   dftd3_get_pairwise_dispersion(error, mol, disp, param, pair_disp2, pair_disp3);
+   if (dftd3_check_error(error)) {return 1;}
+   dftd3_delete(param);
+
+   // PBE-D3(Z)-ATM
+   param = dftd3_new_z_damping(error, 1.0, 1.0, 1.0, 200770.0, 14.0);
+   if (dftd3_check_error(error)) {return 1;}
+   assert(!!param);
+   dftd3_get_dispersion(error, mol, disp, param, &energy, NULL, NULL);
+   if (dftd3_check_error(error)) {return 1;}
+   dftd3_get_dispersion(error, mol, disp, param, &energy, gradient, sigma);
+   if (dftd3_check_error(error)) {return 1;}
+   dftd3_delete(param);
+
    // PBE-D3(CSO)-ATM
    param = dftd3_load_cso_damping(error, "pbe", true);
    if (dftd3_check_error(error)) {return 1;}

--- a/test/unit/test_dftd3.f90
+++ b/test/unit/test_dftd3.f90
@@ -79,6 +79,8 @@ subroutine collect_dftd3(testsuite)
       & new_unittest("B97h-D3(op)", test_b97hd3op_mb37), &
       & new_unittest("TPSSh-D3(op)", test_tpsshd3op_mb38), &
       & new_unittest("B3LYP-D3(CSO)", test_b3lypd3cso_mb01), &
+      & new_unittest("PBE-D3(Z)", test_pbed3z_mb39), &
+      & new_unittest("PBE-D3(Z) sensitive gradient", test_pbed3z_sensitive_grad), &
       & new_unittest("PBE-D3(CSO)-ATM", test_pbed3cso_mb02), &
       & new_unittest("PBE-D3(BJ) Actinides", test_pbed3bj_actinides), &
       & new_unittest("PBE-D3(BJ)-ATM smooth cutoff gradient", test_pbed3bjatm_smooth_cutoff_grad) &
@@ -957,6 +959,43 @@ subroutine test_pbed3cso_mb02(error)
    call test_numsigma(error, mol, param)
 
 end subroutine test_pbed3cso_mb02
+
+subroutine test_pbed3z_mb39(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: mol
+   type(z_damping_param) :: param
+   type(d3_param) :: inp = d3_param(&
+      & s6 = 1.0_wp, s9 = 0.0_wp, alp = 14.0_wp, &
+      & a1 = 200770.0_wp, a2 = 0.0_wp, rs6 = 0.0_wp, rs8 = 6.25_wp)
+
+   call get_structure(mol, "MB16-43", "39")
+   call new_z_damping(param, inp)
+   call test_dftd3_gen(error, mol, param, -6.7659132584659484E-003_wp)
+   if (allocated(error)) return
+   call test_numgrad(error, mol, param)
+
+end subroutine test_pbed3z_mb39
+
+
+subroutine test_pbed3z_sensitive_grad(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: mol
+   type(z_damping_param) :: param
+   type(d3_param) :: inp = d3_param(&
+      & s6 = 1.0_wp, s8 = 1.0_wp, s9 = 0.0_wp, alp = 14.0_wp, &
+      & a1 = 1.0_wp, a2 = 0.0_wp)
+
+   call get_structure(mol, "MB16-43", "01")
+   call new_z_damping(param, inp)
+   call test_numgrad(error, mol, param)
+
+end subroutine test_pbed3z_sensitive_grad
 
 
 subroutine test_pbed3bj_actinides(error)

--- a/test/unit/test_param.f90
+++ b/test/unit/test_param.f90
@@ -51,12 +51,15 @@ subroutine collect_param(testsuite)
       & new_unittest("DFT-D3(op)-ATM", test_d3opatm_mb07), &
       & new_unittest("DFT-D3(CSO)", test_d3cso_mb01), &
       & new_unittest("DFT-D3(CSO)-ATM", test_d3csoatm_mb02), &
+      & new_unittest("DFT-D3(Z)", test_d3z_mb01), &
+      & new_unittest("DFT-D3(Z)-ATM", test_d3zatm_mb02), &
       & new_unittest("unknown-D3(BJ)", test_d3bj_unknown, should_fail=.true.), &
       & new_unittest("unknown-D3(0)", test_d3zero_unknown, should_fail=.true.), &
       & new_unittest("unknown-D3(BJM)", test_d3bjm_unknown, should_fail=.true.), &
       & new_unittest("unknown-D3(0M)", test_d3zerom_unknown, should_fail=.true.), &
       & new_unittest("unknown-D3(op)", test_d3op_unknown, should_fail=.true.), &
-      & new_unittest("unknown-D3(CSO)", test_d3cso_unknown, should_fail=.true.) &
+      & new_unittest("unknown-D3(CSO)", test_d3cso_unknown, should_fail=.true.), &
+      & new_unittest("unknown-D3(Z)", test_d3z_unknown, should_fail=.true.) &
       & ]
 
 end subroutine collect_param
@@ -692,6 +695,73 @@ subroutine test_d3cso_unknown(error)
    call get_cso_damping(inp, "unknown", error)
 
 end subroutine test_d3cso_unknown
+
+subroutine test_d3z_mb01(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: mol
+   type(z_damping_param) :: param
+   type(d3_param) :: inp
+
+   integer :: ii
+   real(wp), parameter :: z_damp(*) = [ &
+      & 200770.0_wp, 116996.0_wp, 39880.0_wp, 238489.0_wp, 153336.0_wp, 65559.0_wp, 78928.0_wp]
+   real(wp), parameter :: ref(*) = [&
+      & -6.2551783612163356E-03_wp,-9.8808891435433581E-03_wp,-2.3868703941633478E-02_wp, &
+      & -5.3958245893503216E-03_wp,-7.8680209293576029E-03_wp,-1.5960626009467203E-02_wp, &
+      & -1.3704275549415742E-02_wp]
+
+   call get_structure(mol, "MB16-43", "01")
+   do ii = 1, size(z_damp)
+      inp = d3_param(s6=1.0_wp, s8=1.0_wp, s9=0.0_wp, a1=z_damp(ii), a2=0.0_wp, alp=14.0_wp)
+      call new_z_damping(param, inp)
+      call test_dftd3_gen(error, mol, param, ref(ii))
+      if (allocated(error)) exit
+   end do
+
+end subroutine test_d3z_mb01
+
+
+subroutine test_d3zatm_mb02(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(structure_type) :: mol
+   type(z_damping_param) :: param
+   type(d3_param) :: inp
+
+   integer :: ii
+   real(wp), parameter :: z_damp(*) = [ &
+      & 200770.0_wp, 116996.0_wp, 39880.0_wp, 238489.0_wp, 153336.0_wp, 65559.0_wp, 78928.0_wp]
+   real(wp), parameter :: ref(*) = [&
+      & -5.1690503588685066E-03_wp,-8.2906998571292134E-03_wp,-2.0256565057237101E-02_wp, &
+      & -4.4307492007790387E-03_wp,-6.5571365397258143E-03_wp,-1.3513507792727777E-02_wp, &
+      & -1.1578682848794588E-02_wp]
+
+   call get_structure(mol, "MB16-43", "02")
+   do ii = 1, size(z_damp)
+      inp = d3_param(s6=1.0_wp, s8=1.0_wp, s9=1.0_wp, a1=z_damp(ii), a2=0.0_wp, alp=14.0_wp)
+      call new_z_damping(param, inp)
+      call test_dftd3_gen(error, mol, param, ref(ii))
+      if (allocated(error)) exit
+   end do
+
+end subroutine test_d3zatm_mb02
+
+
+subroutine test_d3z_unknown(error)
+
+   !> Error handling
+   type(error_type), allocatable, intent(out) :: error
+
+   type(d3_param) :: inp
+
+   call get_z_damping(inp, "unknown", error)
+
+end subroutine test_d3z_unknown
 
 
 end module test_param


### PR DESCRIPTION
Introduced in https://doi.org/10.1063/5.0207682 and https://arxiv.org/abs/2602.04172

There are currently no D3(Z) parameters predefined, but can be instantiated for example based on published XDM(Z) values. *a1* value should be between ~40,000 to ~400,000 in atomic units (1/Eh).